### PR TITLE
ci macos: revert "ci macos: add workaround for msgpack-c"

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -196,13 +196,6 @@ jobs:
           path: ccache
           key: autotools-macos-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**') }}
           restore-keys: autotools-macos-ccache-
-      - name: Adjust msgpack-c.pc
-        run: |
-          sed \
-            -i.bak \
-            -E \
-            -e 's,^(include|lib)dir=,\1dir=${prefix}/,g' \
-            $(brew --prefix msgpack)/lib/pkgconfig/msgpack-c.pc
       - name: Generate configure
         run: |
           ./autogen.sh


### PR DESCRIPTION
This reverts commit 8275463f7d8f8fc7308b232049fdb0cf538bd3d5.

The new msgpack-c package has just released, which resolves this problem at upstream.

ref: https://github.com/Homebrew/homebrew-core/pull/175543
ref: https://github.com/msgpack/msgpack-c/releases/tag/c-6.0.2